### PR TITLE
SQL EnableRetryOnFailure()

### DIFF
--- a/DaytaCare/Startup.cs
+++ b/DaytaCare/Startup.cs
@@ -39,7 +39,10 @@ namespace DaytaCare
             {
                 string connectionString = Configuration.GetConnectionString("DefaultConnection");
 
-                options.UseSqlServer(connectionString);
+                options.UseSqlServer(connectionString, o =>
+                {
+                    o.EnableRetryOnFailure();
+                });
             });
 
 


### PR DESCRIPTION
App crashed on Startup because the Azure SQL Server was sleepy. This should give it a chance to warm up before it just gives up.